### PR TITLE
'import' relative path: new 'relativePath' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ e.g. If the basePath is `/^resource:\/\/`, `resource://activity-stream/foo.js` w
 "plugins": ["transform-react-jsx", {basePath: "resource://activity-stream/"}],
 ```
 
+### `relativePath`
+Defaults to `false`. Rewrite import path as relative.
+
 ### `removeOtherImports`
 
 Defaults to `false`. Should we remove non-matching imports?


### PR DESCRIPTION
This PR proposes an new transform `relativePath` boolean option which allows to rewrite ES modules imports as [relative paths](https://2ality.com/2019/04/nodejs-esm-impl.html#categories-of-module-specifiers).

If a module is compiled by default as:
```js
import { Bar } from "/bar.js";
export class Foo extends Bar {}
```
Compiling with `relativePath` option ouputs:
```js
import { Bar } from "./bar.js";
export class Foo extends Bar {}
```

_Note: [MDN `import` documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)  doesn't mention examples with dot-based relative paths._